### PR TITLE
[CI] Prevent duplicate PR entries in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+no-duplicate-categories: true
 name-template: "v$NEXT_PATCH_VERSION"
 tag-template: "v$NEXT_PATCH_VERSION"
 categories:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Description

This PR upgrades the Release Drafter GitHub Action to a version that supports
`no-duplicate-categories` and enables it in the configuration to ensure that
each merged pull request appears only once in draft release notes.

Fixes #52

## Notes for Reviewers

- Release Drafter action upgraded to v6
- No other workflow behavior changed
- Configuration validated against the updated action

## Signed commits

- [x] Yes, I signed my commits.
